### PR TITLE
Implement validations, running timer and sending events

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 node_modules/**
 demo/build/**
 demo/node_modules/**
+coverage/**

--- a/demo/src/rise-data-counter.html
+++ b/demo/src/rise-data-counter.html
@@ -33,13 +33,17 @@
 
 <body>
 
-<rise-data-counter id="rise-data-counter-01">
+<rise-data-counter id="rise-data-counter-01" type="down" refresh="10" date="2019-10-29">
 </rise-data-counter>
 
 <script>
   function configureComponents() {
     const riseDataCounter01 = document.querySelector('#rise-data-counter-01');
     console.log('Rise components ready');
+
+    riseDataCounter01.addEventListener( "data-update", evt => {
+      console.log( "data-update", evt.detail );
+    } );
 
     // Uncomment if testing directly in browser
     // [ riseDataCounter01 ].forEach( el => RisePlayerConfiguration.Helpers.sendStartEvent( el ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,6 +1986,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
+    "moment": "^2.24.0",
     "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.2.1"
   },
   "devDependencies": {

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -1,5 +1,10 @@
+/* eslint-disable no-console */
+
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { timeOut } from "@polymer/polymer/lib/utils/async.js";
+import { Debouncer } from "@polymer/polymer/lib/utils/debounce.js";
+import moment from "moment";
 import { version } from "./rise-data-counter-version.js";
 
 export default class RiseDataCounter extends RiseElement {
@@ -54,14 +59,125 @@ export default class RiseDataCounter extends RiseElement {
     ];
   }
 
+  // Event name constants
+  static get EVENT_DATA_UPDATE() {
+    return "data-update";
+  }
+
+  static get EVENT_DATA_ERROR() {
+    return "data-error";
+  }
+
+  static get EVENT_RESET() {
+    return "data-counter-reset";
+  }
+
   constructor() {
     super();
 
     this._setVersion( version );
+    this._initialStart = true;
+    this._refreshDebounceJob = null;
+  }
+
+  ready() {
+    super.ready();
+
+    this.addEventListener( "rise-presentation-play", () => this._reset());
+    this.addEventListener( "rise-presentation-stop", () => this._stop());
   }
 
   _reset() {
+    if ( !this._initialStart ) {
+      this._stop();
+      this._start();
+    }
+  }
 
+  _isValidType( type ) {
+    return type === "up" || type === "down";
+  }
+
+  _isValidDate( date ) {
+    return( moment( date, "YYYY-MM-DD", true ).isValid() );
+  }
+
+  _isValidTime( time ) {
+    return( moment( time, "HH:mm", true ).isValid() );
+  }
+
+  _hasValidFormat() {
+    if ( !this.date && !this.time ) {
+      return false;
+    }
+
+    if ( this.date ) {
+      // default on using date value if for some reason time is also provided
+      return this._isValidDate( this.date );
+    }
+
+    if ( this.time ) {
+      return this._isValidTime( this.time );
+    }
+  }
+
+  _start() {
+    if ( !this._isValidType( this.type ) ) {
+      // TODO: log error
+      return;
+    }
+
+    if ( !this._hasValidFormat() ) {
+      // TODO: only log error if date or time has a value
+      return;
+    }
+
+    this._runTimer( this.refresh );
+  }
+
+  _stop() {
+    this._refreshDebounceJob && this._refreshDebounceJob.cancel();
+    // TODO: clear things
+  }
+
+  _sendCounterEvent( eventName, detail ) {
+    super._sendEvent( eventName, detail );
+
+    switch ( eventName ) {
+      case RiseDataCounter.EVENT_DATA_ERROR:
+        super._setUptimeError( true );
+        break;
+      case RiseDataCounter.EVENT_DATA_UPDATE:
+        super._setUptimeError( false );
+        break;
+      default:
+    }
+  }
+
+  _processCount() {
+    // TODO: get difference as timestamp based on type and date or time
+    // TODO: format object for event
+    // temporarily send current timestamp (ISO)
+    this._sendCounterEvent( RiseDataCounter.EVENT_DATA_UPDATE, new Date().toISOString() );
+    this._runTimer( this.refresh );
+  }
+
+  _runTimer( interval ) {
+    interval = parseInt( interval, 10 );
+
+    if ( !isNaN( interval ) && interval > 0 ) {
+      this._refreshDebounceJob = Debouncer.debounce( this._refreshDebounceJob, timeOut.after( interval * 1000 ), () => this._processCount() );
+    }
+  }
+
+  _handleStart() {
+    super._handleStart();
+
+    if (this._initialStart) {
+      this._initialStart = false;
+
+      this._start();
+    }
   }
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,8 @@
   <script>
     // Load and run all tests (.html, .js):
     WCT.loadSuites([
-      "unit/rise-data-counter.html"
+      "unit/rise-data-counter.html",
+      "integration/rise-data-counter.html"
     ]);
   </script>
 </body>

--- a/test/integration/rise-data-counter.html
+++ b/test/integration/rise-data-counter.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>rise-data-counter test</title>
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+
+  <script type="text/javascript">
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
+  </script>
+
+  <script type="module" src="../../src/rise-data-counter.js"></script>
+</head>
+<body>
+  <test-fixture id="test-date-block">
+    <template>
+      <rise-data-counter type="down" date="2019-10-29" refresh="60"></rise-data-counter>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="test-time-block">
+    <template>
+      <rise-data-counter type="down" time="17:00" refresh="60"></rise-data-counter>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+    suite("rise-data-counter", () => {
+      let sandbox = sinon.createSandbox();
+      let elementDate, elementTime, clock;
+
+      setup(() => {
+        RisePlayerConfiguration.Logger = {
+          info: () => {},
+          warning: () => {},
+          error: () => {}
+        };
+
+        RisePlayerConfiguration.isPreview = () => {
+          return false;
+        };
+
+        clock = sinon.useFakeTimers();
+
+        elementDate = fixture("test-date-block");
+        elementTime = fixture("test-time-block");
+      });
+
+      teardown(()=>{
+        sandbox.restore();
+        clock.restore();
+      });
+
+      suite( "data event", () => {
+        test( "should receive data events per refresh", ( done ) => {
+          const handler = function( evt ) {
+            assert.isString( evt.detail );
+
+            dataCount += 1;
+
+            if (dataCount === 2) {
+              done();
+            }
+
+          };
+
+          let dataCount = 0;
+
+          elementDate.addEventListener( "data-update", handler );
+          elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+          clock.tick(60000);
+          clock.tick(60000);
+        } );
+      } );
+
+      suite( "attribute value change", () => {
+        setup( () => {
+          sandbox.spy( elementDate, "_reset" );
+          sandbox.spy( elementTime, "_reset" );
+        } );
+
+        test( "should reset from date change", ( done ) => {
+          const handler = function( evt ) {
+            assert.isString( evt.detail );
+
+            done();
+          };
+
+          elementDate.addEventListener( "data-update", handler );
+          elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+          elementDate.setAttribute( "date", "2020-01-01" );
+
+          assert.isTrue( elementDate._reset.calledOnce );
+          clock.tick(60000);
+        } );
+
+        test( "should call reset from time change", ( done ) => {
+          const handler = function( evt ) {
+            assert.isString( evt.detail );
+
+            done();
+          };
+
+          elementTime.addEventListener( "data-update", handler );
+          elementTime.dispatchEvent( new CustomEvent( "start" ) );
+
+          elementTime.setAttribute( "time", "20:00" );
+
+          assert.isTrue( elementTime._reset.calledOnce );
+          clock.tick(60000);
+        } );
+
+        test( "should call reset from completion change", ( done ) => {
+          const handler = function( evt ) {
+            assert.isString( evt.detail );
+
+            done();
+          };
+
+          elementTime.addEventListener( "data-update", handler );
+          elementTime.dispatchEvent( new CustomEvent( "start" ) );
+
+          elementTime.setAttribute( "completion", "Test!" );
+
+          assert.isTrue( elementTime._reset.calledOnce );
+          clock.tick(60000);
+        } );
+
+      } );
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -30,10 +30,33 @@
 
     <script type="module">
       suite("rise-data-counter", () => {
-        let element;
+        let sandbox = sinon.createSandbox();
+        let element, clock, riseElement;
 
         setup(() => {
+          RisePlayerConfiguration.Logger = {
+            info: () => {},
+            warning: () => {},
+            error: sinon.spy()
+          };
+
+          RisePlayerConfiguration.isPreview = () => {
+            return false;
+          };
+
+          clock = sinon.useFakeTimers();
+
           element = fixture("test-block");
+
+          riseElement = element.__proto__.__proto__;
+
+          sandbox.spy(riseElement, '_sendEvent');
+          sandbox.stub(riseElement, '_setUptimeError');
+        });
+
+        teardown(()=>{
+          sandbox.restore();
+          clock.restore();
         });
 
         suite("properties", () => {
@@ -41,6 +64,262 @@
             assert.equal(element.type, "down");
           });
         });
+
+        suite("ready", () => {
+          let stub;
+
+          setup(() => {
+            stub = sandbox.stub(window, "addEventListener");
+          });
+
+          test("should listen for rise-components-ready and call init", () => {
+            RisePlayerConfiguration.isConfigured = () => false;
+            element.ready();
+
+            assert.isTrue(stub.calledWith('rise-components-ready'));
+          });
+
+          test("should call _init() if RisePlayerConfiguration is configured", () => {
+            RisePlayerConfiguration.isConfigured = () => true;
+            sandbox.stub(element, '_init');
+
+            element.ready();
+
+            assert.isTrue(element._init.calledOnce);
+            assert.isFalse(stub.calledOnce);
+          });
+
+          test("should setup handlers for viewer events", () => {
+            sandbox.stub(element, "_reset");
+            sandbox.stub(element, "_stop");
+
+            element.dispatchEvent( new CustomEvent( "rise-presentation-play" ));
+            element.dispatchEvent( new CustomEvent( "rise-presentation-stop" ));
+
+            assert.isTrue(element._reset.calledOnce);
+            assert.isTrue(element._stop.calledOnce);
+          });
+
+        });
+
+        suite( "_isValidType", () => {
+
+          test( "should return true if 'type' attribute is 'down'", () => {
+            assert.isTrue( element._isValidType( "down" ) );
+          } );
+
+          test( "should return true if 'type' attribute is 'up'", () => {
+            assert.isTrue( element._isValidType( "up" ) );
+          } );
+
+          test( "should return false when invalid", () => {
+            assert.isFalse( element._isValidType( "test" ) );
+          } );
+
+        } );
+
+        suite( "_isValidDate", () => {
+
+          test( "should return true if 'date' has correct strict format YYYY-MM-DD", () => {
+            assert.isTrue( element._isValidDate( "2019-10-29" ) );
+          } );
+
+          test( "should return false if 'date' has incorrect strict format", () => {
+            assert.isFalse( element._isValidDate( "2019-29-10" ) );
+            assert.isFalse( element._isValidDate( "29-10-2019" ) );
+            assert.isFalse( element._isValidDate( "2019-10-29T15:18:06.960Z" ) );
+          } );
+
+        } );
+
+        suite( "_isValidTime", () => {
+
+          test( "should return true if 'time' has correct strict format HH:mm", () => {
+            assert.isTrue( element._isValidTime( "16:20" ) );
+          } );
+
+          test( "should return false if 'time' has incorrect strict format", () => {
+            assert.isFalse( element._isValidTime( "16-20" ) );
+            assert.isFalse( element._isValidTime( "16.20" ) );
+            assert.isFalse( element._isValidDate( "16:20:06" ) );
+            assert.isFalse( element._isValidDate( "2019-10-29T15:18:06.960Z" ) );
+          } );
+
+        } );
+
+        suite( "_hasValidFormat", () => {
+
+          test( "should return false if no 'date' or 'time' value", () => {
+            assert.isFalse( element._hasValidFormat() );
+          } );
+
+          test( "should return false if 'date' configured with invalid format", () => {
+            element.date = "test";
+            assert.isFalse( element._hasValidFormat() );
+          } );
+
+          test( "should return false if 'time' configured with invalid format", () => {
+            element.time = "test";
+            assert.isFalse( element._hasValidFormat() );
+          } );
+
+          test( "should return true if 'date' configured with valid format", () => {
+            element.date = "2019-10-29";
+            assert.isTrue( element._hasValidFormat() );
+          } );
+
+          test( "should return true if 'time' configured with valid format", () => {
+            element.time = "16:20";
+            assert.isTrue( element._hasValidFormat() );
+          } );
+
+        } );
+
+        suite( "_sendCounterEvent", () => {
+          test( "should process 'data-error' event and set uptime correctly", () => {
+            element._sendCounterEvent( 'data-error', 'test' );
+
+            assert.isTrue( riseElement._sendEvent.calledWith( 'data-error', 'test' ) );
+            assert.isTrue( riseElement._setUptimeError.calledWith( true ) );
+          } );
+
+          test( "should process 'data-update' event and set uptime correctly", () => {
+            element._sendCounterEvent( 'data-update', 'test' );
+
+            assert.isTrue( riseElement._sendEvent.calledWith( 'data-update', 'test' ) );
+            assert.isTrue( riseElement._setUptimeError.calledWith( false ) );
+          } );
+
+        } );
+
+        suite( "_runTimer", () => {
+          test( "should call '_processCount()' after 1 second", () => {
+            sandbox.stub( element, "_processCount" );
+
+            element._runTimer( 1 );
+
+            assert.isFalse( element._processCount.calledOnce );
+
+            clock.tick( 1000 );
+
+            assert.isTrue( element._processCount.calledOnce );
+          } );
+
+          test( "should call '_processCount()' after 1 minute", () => {
+            sandbox.stub( element, "_processCount" );
+
+            element._runTimer( 60 );
+
+            clock.tick( 30000 );
+
+            assert.isFalse( element._processCount.calledOnce );
+
+            clock.tick( 30000 );
+
+            assert.isTrue( element._processCount.calledOnce );
+          } );
+        } );
+
+        suite( "_reset", () => {
+          setup( () => {
+            sandbox.stub( element, "_stop" );
+            sandbox.stub( element, "_start" );
+          } );
+
+          test( "should not execute reset when an initial start still pending", () => {
+            element._reset();
+
+            assert.isFalse( element._stop.calledOnce );
+            assert.isFalse( element._start.calledOnce );
+          } );
+
+          test( "should execute reset when not the initial start", () => {
+            element._initialStart = false;
+            element._reset();
+
+            assert.isTrue( element._stop.calledOnce );
+            assert.isTrue( element._start.calledOnce );
+          } );
+        } );
+
+        suite( "_start", () => {
+          setup( () => {
+            sandbox.stub( element, "_runTimer" );
+          } );
+
+          test( "should call _runTimer() when type and date or time formats are valid", () => {
+            element.type = "down";
+            element.date = "2019-10-29";
+            element._start();
+
+            assert.isTrue( element._runTimer.calledOnce );
+          } );
+
+          test( "should not call _runTimer() when type is invalid", () => {
+            element.type = "test";
+            element.date = "2019-10-29";
+            element._start();
+
+            assert.isFalse( element._runTimer.calledOnce );
+          } );
+
+          test( "should not call _runTimer() when empty date or time values", () => {
+            element.type = "date";
+            element._start();
+
+            assert.isFalse( element._runTimer.calledOnce );
+          } );
+        } );
+
+        suite( "_stop", () => {
+          setup( () => {
+            sandbox.stub( element, "_processCount" );
+          } );
+
+          test( "should cancel the timer", () => {
+            element.type = "down";
+            element.date = "2019-10-29";
+            element.refresh = 60;
+            element._start();
+
+            clock.tick(30000);
+
+            assert.isTrue( element._refreshDebounceJob.isActive() );
+
+            element._stop();
+
+            clock.tick(30000);
+
+            assert.isFalse( element._processCount.called );
+            assert.isFalse( element._refreshDebounceJob.isActive() );
+          } );
+
+        } );
+
+        suite( "_handleStart", () => {
+
+          setup( () => {
+            sandbox.stub( element, "_start" );
+          } );
+
+          test( "should call _start() when this is the initial 'start'", () => {
+            const event = new CustomEvent( "start" );
+            element.dispatchEvent( event );
+
+            assert.isTrue( element._start.calledOnce );
+            assert.isFalse( element._initialStart, "_initialStart set to false" );
+          } );
+
+          test( "should not call _start() when this is not the initial start", () => {
+            element._initialStart = false;
+
+            const event = new CustomEvent( "start" );
+            element.dispatchEvent( event );
+
+            assert.isFalse( element._start.called );
+          } );
+
+        } );
 
       });
     </script>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -16,10 +16,10 @@
       ],
       "thresholds": {
         "global": {
-          "branches": 90,
-          "lines": 90,
-          "functions": 80,
-          "statements": 90
+          "branches": 85,
+          "lines": 92,
+          "functions": 92,
+          "statements": 92
         }
       }
     }


### PR DESCRIPTION
## Description
This is the first of two PRs. This one: 

- Validates `type` value as well as `date` and `time` formats. 
- Handles start and viewer events
- Runs the timer based on `refresh` value, and for now processes by sending a `data-update` event with a temporary fixed timestamp value.  

The second follow up PR will ensure to send `data-update` event with actual data based on configurations and start/end differences. 

## Motivation and Context
Component development

## How Has This Been Tested?
Updated demo and ran it locally to confirm `data-update` events were being received according to `refresh` value. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
