### PR TITLE
Provide complete data in data-update for date type configuration

### DIFF
--- a/test/integration/rise-data-counter.html
+++ b/test/integration/rise-data-counter.html
@@ -64,7 +64,13 @@
       suite( "data event", () => {
         test( "should receive data events per refresh", ( done ) => {
           const handler = function( evt ) {
-            assert.isString( evt.detail );
+            assert.isObject( evt.detail );
+            assert.isObject( evt.detail.date );
+            assert.isNull( evt.detail.time );
+            assert.equal( evt.detail.date.targetDate, "2019-10-29" );
+            assert.equal( evt.detail.date.type, "count down" );
+            assert.isObject( evt.detail.date.duration );
+            assert.isObject( evt.detail.date.difference );
 
             dataCount += 1;
 
@@ -92,7 +98,13 @@
 
         test( "should reset from date change", ( done ) => {
           const handler = function( evt ) {
-            assert.isString( evt.detail );
+            assert.isObject( evt.detail );
+            assert.isObject( evt.detail.date );
+            assert.isNull( evt.detail.time );
+            assert.equal( evt.detail.date.targetDate, "2020-01-01" );
+            assert.equal( evt.detail.date.type, "count down" );
+            assert.isObject( evt.detail.date.duration );
+            assert.isObject( evt.detail.date.difference );
 
             done();
           };
@@ -108,7 +120,11 @@
 
         test( "should call reset from time change", ( done ) => {
           const handler = function( evt ) {
-            assert.isString( evt.detail );
+            assert.isObject( evt.detail );
+            assert.isNull( evt.detail.date );
+            assert.isObject( evt.detail.time );
+
+            // TODO: other assertions once time data formatting is complete
 
             done();
           };
@@ -124,7 +140,11 @@
 
         test( "should call reset from completion change", ( done ) => {
           const handler = function( evt ) {
-            assert.isString( evt.detail );
+            assert.isObject( evt.detail );
+            assert.isNull( evt.detail.date );
+            assert.isObject( evt.detail.time );
+
+            // TODO: other assertions once completion message is handled
 
             done();
           };

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -12,6 +12,7 @@
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
     <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+    <script src="../../node_modules/moment/moment.js"></script>
 
     <script type="text/javascript">
       RisePlayerConfiguration = {
@@ -245,6 +246,7 @@
         suite( "_start", () => {
           setup( () => {
             sandbox.stub( element, "_runTimer" );
+            sandbox.stub( element, "_initializeDateDuration" );
           } );
 
           test( "should call _runTimer() when type and date or time formats are valid", () => {
@@ -253,6 +255,14 @@
             element._start();
 
             assert.isTrue( element._runTimer.calledOnce );
+          } );
+
+          test( "should call _initializeDateDuration() when configured for valid date", () => {
+            element.type = "down";
+            element.date = "2019-10-29";
+            element._start();
+
+            assert.isTrue( element._initializeDateDuration.calledWith( element.date ) );
           } );
 
           test( "should not call _runTimer() when type is invalid", () => {
@@ -285,6 +295,7 @@
             clock.tick(30000);
 
             assert.isTrue( element._refreshDebounceJob.isActive() );
+            assert.isNotNull( element._dateDuration );
 
             element._stop();
 
@@ -292,6 +303,7 @@
 
             assert.isFalse( element._processCount.called );
             assert.isFalse( element._refreshDebounceJob.isActive() );
+            assert.isNull( element._dateDuration );
           } );
 
         } );
@@ -319,6 +331,272 @@
             assert.isFalse( element._start.called );
           } );
 
+        } );
+
+        suite( "_initializeDateDuration", () => {
+          test( "should initialize correct duration with given target date based on 'down' type", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), 2419200000 );
+            assert.equal( element._dateDuration.asDays(), 28 );
+
+            // test a date that is same as target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), 0 );
+            assert.equal( element._dateDuration.asDays(), 0 );
+
+            // test a date that has passed target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-11-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), -259200000 );
+            assert.equal( element._dateDuration.asDays(), -3 );
+
+          } );
+
+          test( "should initialize correct duration with given target date based on 'up' type", () => {
+            // test a date that is after target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-01", "up" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), 2419200000 );
+            assert.equal( element._dateDuration.asDays(), 28 );
+
+            // test a date that is same as target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "up" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), 0 );
+            assert.equal( element._dateDuration.asDays(), 0 );
+
+            // test a date that is before target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "up" );
+
+            assert.equal( element._dateDuration.asMilliseconds(), -2419200000 );
+            assert.equal( element._dateDuration.asDays(), -28 );
+
+          } );
+        } );
+
+        suite( "_updateDateDuration", () => {
+          test( "should update correct duration with given interval (MS) and based on 'down' type", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            assert.equal( element._dateDuration.days(), 28 );
+
+            // simulate a 24 hour interval
+            element._updateDateDuration( 24 * 60 * 60 * 1000, "down" );
+
+            assert.equal( element._dateDuration.days(), 27 );
+
+            // simulate a 10 second interval
+            element._updateDateDuration( 10 * 1000, "down" );
+
+            assert.equal( element._dateDuration.seconds(), 50 );
+
+            element._updateDateDuration( 10 * 1000, "down" );
+
+            assert.equal( element._dateDuration.seconds(), 40 );
+          } );
+
+          test( "should update correct duration with given interval (MS) and based on 'up' type", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-01", "up" );
+
+            assert.equal( element._dateDuration.days(), 28 );
+
+            // simulate a 24 hour interval
+            element._updateDateDuration( 24 * 60 * 60 * 1000, "up" );
+
+            assert.equal( element._dateDuration.days(), 29 );
+
+            // simulate a 10 second interval
+            element._updateDateDuration( 10 * 1000, "up" );
+
+            assert.equal( element._dateDuration.seconds(), 10 );
+
+            element._updateDateDuration( 10 * 1000, "up" );
+
+            assert.equal( element._dateDuration.seconds(), 20 );
+          } );
+        } );
+
+        suite( "_getDateDurationFormatted", () => {
+          test( "should return object with all correct properties and values", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            // simulate a 10 second interval
+            element._updateDateDuration( 10 * 1000, "down" );
+
+            const formatted = element._getDateDurationFormatted();
+
+            assert.deepEqual( formatted, {
+              days: 27,
+              hours: 23,
+              milliseconds: 0,
+              minutes: 59,
+              months: 0,
+              seconds: 50,
+              weeks: 3,
+              years: 0
+            } )
+          } );
+        } );
+
+        suite( "_getDateDifferenceFormatted", () => {
+          test( "should return object with all correct properties and values based on 'down' type", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-29", "down" );
+
+            // simulate a 10 second interval
+            element._updateDateDuration( 10 * 1000, "down" );
+
+            const formatted = element._getDateDifferenceFormatted( "2019-10-29", "down" );
+
+            assert.deepEqual( formatted, {
+              days: 28,
+              hours: 672,
+              milliseconds: 2419200000,
+              minutes: 40320,
+              months: 0,
+              seconds: 2419200,
+              weeks: 4,
+              years: 0
+            } )
+          } );
+
+          test( "should return object with all correct properties and values based on 'up' type", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            element._initializeDateDuration( "2019-10-01", "up" );
+
+            // simulate a 10 second interval
+            element._updateDateDuration( 10 * 1000, "up" );
+
+            const formatted = element._getDateDifferenceFormatted( "2019-10-01", "up" );
+
+            assert.deepEqual( formatted, {
+              days: 28,
+              hours: 672,
+              milliseconds: 2419200000,
+              minutes: 40320,
+              months: 0,
+              seconds: 2419200,
+              weeks: 4,
+              years: 0
+            } )
+          } );
+        } );
+
+        suite( "_getDateData", () => {
+          test( "should return object with all correct properties and values", () => {
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element.date = "2019-10-29";
+            element.type = "down";
+            element.refresh = 10;
+
+            element._start();
+
+            const data = element._getDateData();
+
+            assert.deepEqual( data, {
+              targetDate: "2019-10-29",
+              type: "count down",
+              duration: {
+                days: 27,
+                hours: 23,
+                milliseconds: 0,
+                minutes: 59,
+                months: 0,
+                seconds: 50,
+                weeks: 3,
+                years: 0
+              },
+              difference: {
+                days: 28,
+                hours: 672,
+                milliseconds: 2419200000,
+                minutes: 40320,
+                months: 0,
+                seconds: 2419200,
+                weeks: 4,
+                years: 0
+              }
+            });
+          } );
+
+        } );
+
+        suite( "_processCount", () => {
+          test( "should send 'data-update' event and run timer", () => {
+            sandbox.stub(element, "_sendCounterEvent");
+            sandbox.stub(element, "_runTimer");
+
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element.date = "2019-10-29";
+            element.type = "down";
+            element.refresh = 10;
+
+            element._start();
+            element._processCount();
+
+            assert.isTrue( element._sendCounterEvent.calledWith( 'data-update', {
+              date: {
+                targetDate: "2019-10-29",
+                type: "count down",
+                duration: {
+                  days: 27,
+                  hours: 23,
+                  milliseconds: 0,
+                  minutes: 59,
+                  months: 0,
+                  seconds: 50,
+                  weeks: 3,
+                  years: 0
+                },
+                difference: {
+                  days: 28,
+                  hours: 672,
+                  milliseconds: 2419200000,
+                  minutes: 40320,
+                  months: 0,
+                  seconds: 2419200,
+                  weeks: 4,
+                  years: 0
+                }
+              },
+              time: null
+            } ) );
+
+            assert.isTrue( element._runTimer.calledWith( 10 ) );
+
+          } );
         } );
 
       });

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -17,9 +17,9 @@
       "thresholds": {
         "global": {
           "branches": 85,
-          "lines": 92,
-          "functions": 92,
-          "statements": 92
+          "lines": 95,
+          "functions": 95,
+          "statements": 95
         }
       }
     }


### PR DESCRIPTION
## Description
When configured for a `date`, the _data-update_ event now provides a formatted object of data, calculated to a specific type configuration of `down` or `up`. The format is as shown in console screenshot below:

![image](https://user-images.githubusercontent.com/7407007/67411782-26ff4180-f58c-11e9-8f12-7e89daeb2a21.png)

The `duration` and `difference` objects provide a unit breakdown representative of the current _moment_ of time that is remaining to count up/down to the target date. If values are negative, it means that the current moment is **after** the target date of a _down_ type, and if configured for _up_, it means the current moment is **before** the target date to start from. 

The `duration` values provide a convenient means of using the exact unit values, for example to use for a running clock countdown. 

The `difference` values provide the total values of each unit providing a convenient way to use a total, for example the total `days` left until Halloween. 

`targetDate` and `type` are also provided as additional helper info to know what was configured for the instance. 

## Motivation and Context
Component development

## How Has This Been Tested?
Tested locally with demo file and Charles

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
