### PR TITLE
Chore/time

### DIFF
--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -176,7 +176,7 @@ export default class RiseDataCounter extends RiseElement {
   }
 
   _formatMomentJSMonth( month ) {
-    if ( !month || isNaN( month ) || month < 0 || month > 12) {
+    if ( !month || isNaN( month ) || month < 0 || month > 11) {
       return "";
     }
 

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -80,8 +80,12 @@ export default class RiseDataCounter extends RiseElement {
     return "up";
   }
 
-  static get MOMENT_UNITS() {
+  static get MOMENT_DATE_UNITS() {
     return ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"];
+  }
+
+  static get MOMENT_TIME_UNITS() {
+    return ["hours", "minutes", "seconds", "milliseconds"];
   }
 
   constructor() {
@@ -91,6 +95,7 @@ export default class RiseDataCounter extends RiseElement {
     this._initialStart = true;
     this._refreshDebounceJob = null;
     this._dateDuration = null;
+    this._timeDuration = null;
   }
 
   ready() {
@@ -146,6 +151,7 @@ export default class RiseDataCounter extends RiseElement {
     }
 
     this.date && this._initializeDateDuration( this.date, this.type );
+    !this.date && this.time && this._initializeTimeDuration( this.time, this.type );
 
     this._runTimer( this.refresh );
   }
@@ -169,6 +175,21 @@ export default class RiseDataCounter extends RiseElement {
     }
   }
 
+  _formatMomentJSMonth( month ) {
+    if ( !month || isNaN( month ) || month < 0 || month > 12) {
+      return "";
+    }
+
+    // momentjs month is zero indexed based
+    month += 1;
+
+    if ( month < 10 ) {
+      return `0${ month }`
+    }
+
+    return month;
+  }
+
   _initializeDateDuration( targetDate, type ) {
     const targetDateInMS = moment( targetDate, "YYYY-MM-DD" ).valueOf(),
       currentDateInMS = moment().valueOf(),
@@ -177,15 +198,38 @@ export default class RiseDataCounter extends RiseElement {
     this._dateDuration = moment.duration(calculation, "milliseconds");
   }
 
+  _initializeTimeDuration( targetTime, type ) {
+    const current = moment(),
+      target = moment( `${ current.year() }-${ this._formatMomentJSMonth( current.month() ) }-${current.date()}T${ targetTime }`, "YYYY-MM-DDTHH:mm" ),
+      targetTimeInMS = target.valueOf(),
+      currentTimeInMS = current.valueOf(),
+      calculation = type === RiseDataCounter.TYPE_DOWN ? targetTimeInMS - currentTimeInMS : currentTimeInMS - targetTimeInMS;
+
+    this._timeDuration = moment.duration(calculation, "milliseconds");
+  }
+
   _updateDateDuration( intervalMS, type ) {
     const calculation = type === RiseDataCounter.TYPE_DOWN ? this._dateDuration - intervalMS : this._dateDuration + intervalMS;
 
     this._dateDuration = moment.duration(calculation, "milliseconds");
   }
 
+  _updateTimeDuration( intervalMS, type ) {
+    const calculation = type === RiseDataCounter.TYPE_DOWN ? this._timeDuration - intervalMS : this._timeDuration + intervalMS;
+
+    this._timeDuration = moment.duration(calculation, "milliseconds");
+  }
+
   _getDateDurationFormatted() {
-    return RiseDataCounter.MOMENT_UNITS.reduce( (duration, unit) => {
+    return RiseDataCounter.MOMENT_DATE_UNITS.reduce( (duration, unit) => {
       duration[ unit ] = this._dateDuration[unit]();
+      return duration;
+    }, {});
+  }
+
+  _getTimeDurationFormatted() {
+    return RiseDataCounter.MOMENT_TIME_UNITS.reduce( (duration, unit) => {
+      duration[ unit ] = this._timeDuration[unit]();
       return duration;
     }, {});
   }
@@ -198,7 +242,21 @@ export default class RiseDataCounter extends RiseElement {
       return type === RiseDataCounter.TYPE_DOWN ? event.diff( now, unit ) : now.diff( event, unit );
     }
 
-    return RiseDataCounter.MOMENT_UNITS.reduce( (difference, unit) => {
+    return RiseDataCounter.MOMENT_DATE_UNITS.reduce( (difference, unit) => {
+      difference[ unit ] = getValue( unit );
+      return difference;
+    }, {});
+  }
+
+  _getTimeDifferenceFormatted( targetTime, type ) {
+    const now = moment(),
+      event = moment( `${ now.year() }-${ this._formatMomentJSMonth( now.month() ) }-${now.date()}T${ targetTime }`, "YYYY-MM-DDTHH:mm" );
+
+    function getValue( unit ) {
+      return type === RiseDataCounter.TYPE_DOWN ? event.diff( now, unit ) : now.diff( event, unit );
+    }
+
+    return RiseDataCounter.MOMENT_TIME_UNITS.reduce( (difference, unit) => {
       difference[ unit ] = getValue( unit );
       return difference;
     }, {});
@@ -216,8 +274,14 @@ export default class RiseDataCounter extends RiseElement {
   }
 
   _getTimeData() {
-    // TODO
-    return {};
+    const data = { targetTime: this.time, type: `count ${this.type}` };
+
+    this._updateTimeDuration( this.refresh * 1000, this.type );
+
+    data.difference = this._getTimeDifferenceFormatted( this.time, this.type );
+    data.duration = this._getTimeDurationFormatted();
+
+    return data;
   }
 
   _processCount() {

--- a/test/integration/rise-data-counter.html
+++ b/test/integration/rise-data-counter.html
@@ -123,8 +123,10 @@
             assert.isObject( evt.detail );
             assert.isNull( evt.detail.date );
             assert.isObject( evt.detail.time );
-
-            // TODO: other assertions once time data formatting is complete
+            assert.equal( evt.detail.time.targetTime, "20:00" );
+            assert.equal( evt.detail.time.type, "count down" );
+            assert.isObject( evt.detail.time.duration );
+            assert.isObject( evt.detail.time.difference );
 
             done();
           };

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -599,6 +599,213 @@
           } );
         } );
 
+        suite( "_formatMomentJSMonth", () => {
+          test( "should return empty when value is NaN or out of 0 - 11 range", () => {
+            assert.equal( element._formatMomentJSMonth(), "" );
+            assert.equal( element._formatMomentJSMonth("test"), "" );
+            assert.equal( element._formatMomentJSMonth(12), "" );
+            assert.equal( element._formatMomentJSMonth(-1), "" );
+          } );
+
+          test( "should return month correctly formatted", () => {
+            assert.equal( element._formatMomentJSMonth( 2 ), "03" );
+            assert.equal( element._formatMomentJSMonth( 9 ), "10" );
+            assert.equal( element._formatMomentJSMonth( 11 ), "12" );
+          });
+        } );
+
+        suite( "_initializeTimeDuration", () => {
+          test( "should initialize correct duration with given target time based on 'down' type", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            assert.equal( element._timeDuration.hours(), 3 );
+            assert.equal( element._timeDuration.minutes(), 30 );
+
+            // test a time that is same as target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "13:30", "down" );
+
+            assert.equal( element._timeDuration.hours(), 0 );
+            assert.equal( element._timeDuration.minutes(), 0 );
+
+            // test a time that has passed target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T18:45", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            assert.equal( element._timeDuration.hours(), -1 );
+            assert.equal( element._timeDuration.minutes(), -45 );
+
+          } );
+
+          test( "should initialize correct duration with given target time based on 'up' type", () => {
+            // test a time that is after target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "09:00", "up" );
+
+            assert.equal( element._timeDuration.hours(), 4 );
+            assert.equal( element._timeDuration.minutes(), 30 );
+
+            // test a time that is same as target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "13:30", "up" );
+
+            assert.equal( element._timeDuration.hours(), 0 );
+            assert.equal( element._timeDuration.minutes(), 0 );
+
+            // test a time that is before target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "up" );
+
+            assert.equal( element._timeDuration.hours(), -3 );
+            assert.equal( element._timeDuration.minutes(), -30 );
+
+          } );
+        } );
+
+        suite( "_updateTimeDuration", () => {
+          test( "should update correct duration with given interval (MS) and based on 'down' type", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            assert.equal( element._timeDuration.hours(), 3 );
+            assert.equal( element._timeDuration.minutes(), 30 );
+            assert.equal( element._timeDuration.seconds(), 0 );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "down" );
+
+            assert.equal( element._timeDuration.seconds(), 50 );
+
+            element._updateTimeDuration( 10 * 1000, "down" );
+
+            assert.equal( element._timeDuration.seconds(), 40 );
+          } );
+
+          test( "should update correct duration with given interval (MS) and based on 'up' type", () => {
+            // test a time that is after target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "9:00", "up" );
+
+            assert.equal( element._timeDuration.hours(), 4 );
+            assert.equal( element._timeDuration.minutes(), 30 );
+            assert.equal( element._timeDuration.seconds(), 0 );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "up" );
+
+            assert.equal( element._timeDuration.seconds(), 10 );
+
+            element._updateTimeDuration( 10 * 1000, "up" );
+
+            assert.equal( element._timeDuration.seconds(), 20 );
+          } );
+        } );
+
+        suite( "_getTimeDurationFormatted", () => {
+          test( "should return object with all correct properties and values", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "down" );
+
+            const formatted = element._getTimeDurationFormatted();
+
+            assert.deepEqual( formatted, {
+              hours: 3,
+              milliseconds: 0,
+              minutes: 29,
+              seconds: 50
+            } )
+          } );
+        } );
+
+        suite( "_getTimeDifferenceFormatted", () => {
+          test( "should return object with all correct properties and values based on 'down' type", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "down" );
+
+            const formatted = element._getTimeDifferenceFormatted( "17:00", "down" );
+
+            assert.deepEqual( formatted, {
+              hours: 3,
+              milliseconds: 12600000,
+              minutes: 210,
+              seconds: 12600,
+            } )
+          } );
+
+          test( "should return object with all correct properties and values based on 'up' type", () => {
+            // test a time that is after target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "9:00", "up" );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "up" );
+
+            const formatted = element._getTimeDifferenceFormatted( "09:00", "up" );
+
+            assert.deepEqual( formatted, {
+              hours: 4,
+              milliseconds: 16200000,
+              minutes: 270,
+              seconds: 16200,
+            } )
+          } );
+        } );
+
+        suite( "_getTimeData", () => {
+          test( "should return object with all correct properties and values", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element.time = "17:00";
+            element.type = "down";
+            element.refresh = 10;
+
+            element._start();
+
+            const data = element._getTimeData();
+
+            assert.deepEqual( data, {
+              targetTime: "17:00",
+              type: "count down",
+              duration: {
+                hours: 3,
+                milliseconds: 0,
+                minutes: 29,
+                seconds: 50
+              },
+              difference: {
+                hours: 3,
+                milliseconds: 12600000,
+                minutes: 210,
+                seconds: 12600
+              }
+            });
+          } );
+
+        } );
+
       });
     </script>
   </body>


### PR DESCRIPTION
## Description
When configured for a `time`, the _data-update_ event now provides a formatted object of data, calculated to a specific type configuration of `down` or `up`. The format is as shown in console screenshot below:

![image](https://user-images.githubusercontent.com/7407007/67895330-a498f380-fb30-11e9-8b15-4be065d3ea09.png)


The `duration` and `difference` objects provide a unit breakdown representative of the current _moment_ of time that is remaining to count down to the target time or count up from the target time. If values are negative, it means that the current moment is **after** the target time of a _down_ type, and if configured for _up_, it means the current moment is **before** the target time to start from. 

The `duration` values provide a convenient means of using the exact unit values, for example to use for a running clock countdown. 

The `difference` values provide the total values of each unit providing a convenient way to use a total, for example the total `minutes` left until the school day is done. 

`targetTime` and `type` are also provided as additional helper info to know what was configured for the instance. 

## Motivation and Context
Component development

## How Has This Been Tested?
Tested locally with demo file and Charles

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
