### PR TITLE
Support the completion feature

### DIFF
--- a/demo/src/rise-data-counter.html
+++ b/demo/src/rise-data-counter.html
@@ -33,7 +33,7 @@
 
 <body>
 
-<rise-data-counter id="rise-data-counter-01" type="down" refresh="10" date="2019-10-29">
+<rise-data-counter id="rise-data-counter-01" type="down" refresh="10" date="2020-01-01" completion="I'm done!">
 </rise-data-counter>
 
 <script>

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -266,7 +266,7 @@ export default class RiseDataCounter extends RiseElement {
     return false;
   }
 
-  _getRangeData( type, units ) {
+  _getStatus( type, units ) {
     const data = {};
 
     if ( type === "down" ) {
@@ -289,7 +289,7 @@ export default class RiseDataCounter extends RiseElement {
     data.difference = this._getDateDifferenceFormatted( this.date, this.type );
     data.duration = this._getDateDurationFormatted();
 
-    const rangeData = this._getRangeData( this.type, data.difference );
+    const rangeData = this._getStatus( this.type, data.difference );
 
     return Object.assign( {}, data, rangeData );
   }
@@ -302,7 +302,7 @@ export default class RiseDataCounter extends RiseElement {
     data.difference = this._getTimeDifferenceFormatted( this.time, this.type );
     data.duration = this._getTimeDurationFormatted();
 
-    const rangeData = this._getRangeData( this.type, data.difference );
+    const rangeData = this._getStatus( this.type, data.difference );
 
     return Object.assign( data, rangeData );
   }

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-unused-vars */
 
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { timeOut } from "@polymer/polymer/lib/utils/async.js";
@@ -256,6 +256,31 @@ export default class RiseDataCounter extends RiseElement {
     }, {});
   }
 
+  _isOutOfRange( units ) {
+    for ( let [ key, value] of Object.entries( units ) ) {
+      if (value < 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  _getRangeData( type, units ) {
+    const data = {};
+
+    if ( type === "down" ) {
+      data.completed = this._isOutOfRange( units );
+      data.completion = this.completion;
+    }
+
+    if ( type === "up" ) {
+      data.started = !this._isOutOfRange( units );
+    }
+
+    return data;
+  }
+
   _getDateData() {
     const data = { targetDate: this.date, type: `count ${this.type}` };
 
@@ -264,7 +289,9 @@ export default class RiseDataCounter extends RiseElement {
     data.difference = this._getDateDifferenceFormatted( this.date, this.type );
     data.duration = this._getDateDurationFormatted();
 
-    return data;
+    const rangeData = this._getRangeData( this.type, data.difference );
+
+    return Object.assign( {}, data, rangeData );
   }
 
   _getTimeData() {
@@ -275,7 +302,9 @@ export default class RiseDataCounter extends RiseElement {
     data.difference = this._getTimeDifferenceFormatted( this.time, this.type );
     data.duration = this._getTimeDurationFormatted();
 
-    return data;
+    const rangeData = this._getRangeData( this.type, data.difference );
+
+    return Object.assign( data, rangeData );
   }
 
   _processCount() {

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -526,6 +526,8 @@
             assert.deepEqual( data, {
               targetDate: "2019-10-29",
               type: "count down",
+              completed: false,
+              completion: undefined,
               duration: {
                 days: 27,
                 hours: 23,
@@ -570,6 +572,8 @@
               date: {
                 targetDate: "2019-10-29",
                 type: "count down",
+                completed: false,
+                completion: undefined,
                 duration: {
                   days: 27,
                   hours: 23,
@@ -789,6 +793,8 @@
             assert.deepEqual( data, {
               targetTime: "17:00",
               type: "count down",
+              completed: false,
+              completion: undefined,
               duration: {
                 hours: 3,
                 milliseconds: 0,
@@ -804,6 +810,57 @@
             });
           } );
 
+        } );
+
+        suite( "_isOutOfRange", () => {
+          test( "should return true when out of range", () => {
+            assert.isTrue( element._isOutOfRange( {
+              hours: 0,
+              minutes: 0,
+              seconds: -2,
+              milliseconds: -2000
+            } ) )
+          } );
+
+          test( "should return false when within range", () => {
+            assert.isFalse( element._isOutOfRange( {
+              hours: 3,
+              minutes: 180,
+              seconds: 10800,
+              milliseconds: 10800000
+            } ) )
+          } );
+        } );
+
+        suite( "_getRangeData", () => {
+          test( "should return correct object values when type is 'down'", () => {
+            const units = {
+              hours: 3,
+              minutes: 180,
+              seconds: 10800,
+              milliseconds: 10800000
+            };
+
+            element.completion = "Testing";
+
+            assert.deepEqual( element._getRangeData( "down", units ), {
+              completed: false,
+              completion: "Testing"
+            } );
+          } );
+
+          test( "should return correct object values when type is 'up'", () => {
+            const units = {
+              hours: 3,
+              minutes: 180,
+              seconds: 10800,
+              milliseconds: 10800000
+            };
+
+            assert.deepEqual( element._getRangeData( "up", units ), {
+              started: true
+            } );
+          } );
         } );
 
       });

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -832,7 +832,7 @@
           } );
         } );
 
-        suite( "_getRangeData", () => {
+        suite( "_getStatus", () => {
           test( "should return correct object values when type is 'down'", () => {
             const units = {
               hours: 3,
@@ -843,7 +843,7 @@
 
             element.completion = "Testing";
 
-            assert.deepEqual( element._getRangeData( "down", units ), {
+            assert.deepEqual( element._getStatus( "down", units ), {
               completed: false,
               completion: "Testing"
             } );
@@ -857,7 +857,7 @@
               milliseconds: 10800000
             };
 
-            assert.deepEqual( element._getRangeData( "up", units ), {
+            assert.deepEqual( element._getStatus( "up", units ), {
               started: true
             } );
           } );


### PR DESCRIPTION
## Description
Support the feature of a `completion` message. Additionally provide a status in `data-update` event. When type is _down_, the properties `completed` and `completion` are included. When type is _up_, the property `started` is included. 

## Motivation and Context
Component development

## How Has This Been Tested?
Tested with demo locally as well as with example counter component template via ChrOS player and Charles. Updates were made to the template to show the additional property values which can be seen in the screenshot below. **Note**, at the time of validation, Apps master build had not been deployed so a _completion_ message was not possible to add in template editor for the template. 

![image](https://user-images.githubusercontent.com/7407007/68241134-23cc7280-ffdc-11e9-9803-1ca6d2373a7f.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
