### PR TITLE
Support logging and reporting uptime

### DIFF
--- a/demo/src/rise-data-counter.html
+++ b/demo/src/rise-data-counter.html
@@ -45,6 +45,10 @@
       console.log( "data-update", evt.detail );
     } );
 
+    riseDataCounter01.addEventListener( "data-error", evt => {
+      console.log( "data-error", evt.detail );
+    } );
+
     // Uncomment if testing directly in browser
     // [ riseDataCounter01 ].forEach( el => RisePlayerConfiguration.Helpers.sendStartEvent( el ) );
   }

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -135,12 +135,25 @@ export default class RiseDataCounter extends RiseElement {
 
   _start() {
     if ( !this._isValidType( this.type ) ) {
-      // TODO: log error
+      super.log( "error", "Invalid type", { type: this.type } );
+      this._sendCounterEvent( RiseDataCounter.EVENT_DATA_ERROR, {
+        message: "Invalid type, valid values are 'down' and 'up'",
+        type: this.type
+      } );
       return;
     }
 
     if ( !this._hasValidFormat() ) {
-      // TODO: only log error if date or time has a value
+      // only log error if date or time is not empty
+      if ( this.date || this.time ) {
+        super.log( "error", "Invalid format", { date: this.date, time: this.time } );
+        this._sendCounterEvent( RiseDataCounter.EVENT_DATA_ERROR, {
+          message: "Invalid format, valid date is YYYY-MM-DD and valid time is HH:mm",
+          date: this.date,
+          time: this.time
+        } );
+      }
+
       return;
     }
 

--- a/test/integration/rise-data-counter.html
+++ b/test/integration/rise-data-counter.html
@@ -145,8 +145,7 @@
             assert.isObject( evt.detail );
             assert.isNull( evt.detail.date );
             assert.isObject( evt.detail.time );
-
-            // TODO: other assertions once completion message is handled
+            assert.equal( evt.detail.time.completion, "Test!" );
 
             done();
           };
@@ -160,6 +159,51 @@
           clock.tick(60000);
         } );
 
+      } );
+
+      suite( "logging", () => {
+        const componentData = {
+          name: "rise-data-counter",
+          id: "",
+          version: "__VERSION__"
+        };
+
+        setup( () => {
+          sandbox.spy( RisePlayerConfiguration.Logger, "error" );
+        } );
+
+        test( "should log 'data-error' event when invalid type attribute", () => {
+          elementDate.type = "test";
+          elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
+          assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "Invalid type");
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], { type: "test" } );
+
+          elementDate.type = "down";
+        } );
+
+        test( "should log 'data-error' event when date format invalid", () => {
+          elementDate.date = "29-10-2019";
+          elementDate.dispatchEvent( new CustomEvent( "start" ) );
+
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
+          assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "Invalid format");
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], { date: "29-10-2019", time: undefined } );
+
+          elementDate.date = "2019-10-29";
+        } );
+
+        test( "should log 'data-error' event when time format invalid", () => {
+          elementTime.time = "17:00:35";
+          elementTime.dispatchEvent( new CustomEvent( "start" ) );
+
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
+          assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "Invalid format");
+          assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], { date: undefined, time: "17:00:35" } );
+
+          elementTime.time = "17:00";
+        } );
       } );
     });
   </script>

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -265,19 +265,74 @@
             assert.isTrue( element._initializeDateDuration.calledWith( element.date ) );
           } );
 
-          test( "should not call _runTimer() when type is invalid", () => {
+          test( "should not call _runTimer() and should send data-error event when type is invalid", ( done ) => {
+            const listener = ( evt ) => {
+              assert.deepEqual( evt.detail, {
+                message: "Invalid type, valid values are 'down' and 'up'",
+                type: "test"
+              } );
+
+              assert.isFalse( element._runTimer.calledOnce );
+
+              element.removeEventListener( "data-error", listener );
+              done();
+            };
+
+            element.addEventListener( "data-error", listener );
             element.type = "test";
             element.date = "2019-10-29";
             element._start();
 
-            assert.isFalse( element._runTimer.calledOnce );
           } );
 
-          test( "should not call _runTimer() when empty date or time values", () => {
-            element.type = "date";
+          test( "should not call _runTimer() or send data-error event when empty date or time values", () => {
+            sinon.spy( element, "_sendCounterEvent" );
+
+            element.type = "down";
             element._start();
 
             assert.isFalse( element._runTimer.calledOnce );
+            assert.isFalse( element._sendCounterEvent.calledOnce );
+          } );
+
+          test( "should not call _runTimer() and should send data-error event when date format is invalid", ( done ) => {
+            const listener = ( evt ) => {
+              assert.deepEqual( evt.detail, {
+                message: "Invalid format, valid date is YYYY-MM-DD and valid time is HH:mm",
+                date: element.date,
+                time: element.time
+              } );
+
+              assert.isFalse( element._runTimer.calledOnce );
+
+              element.removeEventListener( "data-error", listener );
+              done();
+            };
+
+            element.addEventListener( "data-error", listener );
+            element.type = "down";
+            element.date = "29-10-2019";
+            element._start();
+          } );
+
+          test( "should not call _runTimer() and should send data-error event when time format is invalid", ( done ) => {
+            const listener = ( evt ) => {
+              assert.deepEqual( evt.detail, {
+                message: "Invalid format, valid date is YYYY-MM-DD and valid time is HH:mm",
+                date: element.date,
+                time: element.time
+              } );
+
+              assert.isFalse( element._runTimer.calledOnce );
+
+              element.removeEventListener( "data-error", listener );
+              done();
+            };
+
+            element.addEventListener( "data-error", listener );
+            element.type = "down";
+            element.time = "01:43:21";
+            element._start();
           } );
         } );
 


### PR DESCRIPTION
## Description
Log errors and send `data-error` events when invalid `type` and invalid formats for `date` or `time`. 

## Motivation and Context
Reliability and uptime reporting for component

## How Has This Been Tested?
Tested locally with demo as well as with example template running via ChrOS player and Charles. Validation of an invalid `type` log in screenshot below:

![image](https://user-images.githubusercontent.com/7407007/68328200-d7953700-009c-11ea-86f9-c9ff962ecebe.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
