### PR TITLE
Immediately process and send data-update event after component starts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-counter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-counter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rise data counter component",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -160,7 +160,7 @@ export default class RiseDataCounter extends RiseElement {
     this.date && this._initializeDateDuration( this.date, this.type );
     !this.date && this.time && this._initializeTimeDuration( this.time, this.type );
 
-    this._runTimer( this.refresh );
+    this._processCount( true );
   }
 
   _stop() {
@@ -294,10 +294,10 @@ export default class RiseDataCounter extends RiseElement {
     return data;
   }
 
-  _getDateData() {
+  _getDateData( ignoreDurationUpdate = false ) {
     const data = { targetDate: this.date, type: `count ${this.type}` };
 
-    this._updateDateDuration( this.refresh * 1000, this.type );
+    !ignoreDurationUpdate && this._updateDateDuration( this.refresh * 1000, this.type );
 
     data.difference = this._getDateDifferenceFormatted( this.date, this.type );
     data.duration = this._getDateDurationFormatted();
@@ -307,10 +307,10 @@ export default class RiseDataCounter extends RiseElement {
     return Object.assign( {}, data, rangeData );
   }
 
-  _getTimeData() {
+  _getTimeData( ignoreDurationUpdate = false ) {
     const data = { targetTime: this.time, type: `count ${this.type}` };
 
-    this._updateTimeDuration( this.refresh * 1000, this.type );
+    !ignoreDurationUpdate && this._updateTimeDuration( this.refresh * 1000, this.type );
 
     data.difference = this._getTimeDifferenceFormatted( this.time, this.type );
     data.duration = this._getTimeDurationFormatted();
@@ -320,11 +320,11 @@ export default class RiseDataCounter extends RiseElement {
     return Object.assign( data, rangeData );
   }
 
-  _processCount() {
+  _processCount( start = false ) {
     const data = {};
 
-    data.date = this.date ? this._getDateData() : null;
-    data.time = !this.date && this.time ? this._getTimeData() : null;
+    data.date = this.date ? this._getDateData( start ) : null;
+    data.time = !this.date && this.time ? this._getTimeData( start ) : null;
 
     this._sendCounterEvent( RiseDataCounter.EVENT_DATA_UPDATE, data );
     this._runTimer( this.refresh );

--- a/test/integration/rise-data-counter.html
+++ b/test/integration/rise-data-counter.html
@@ -62,6 +62,23 @@
       });
 
       suite( "data event", () => {
+        test( "should receive data event immediately after component starts", (done) => {
+          const handler = function( evt ) {
+            assert.isObject( evt.detail );
+            assert.isObject( evt.detail.date );
+            assert.isNull( evt.detail.time );
+            assert.equal( evt.detail.date.targetDate, "2019-10-29" );
+            assert.equal( evt.detail.date.type, "count down" );
+            assert.isObject( evt.detail.date.duration );
+            assert.isObject( evt.detail.date.difference );
+
+            done();
+          };
+
+          elementDate.addEventListener( "data-update", handler );
+          elementDate.dispatchEvent( new CustomEvent( "start" ) );
+        } );
+
         test( "should receive data events per refresh", ( done ) => {
           const handler = function( evt ) {
             assert.isObject( evt.detail );
@@ -109,12 +126,12 @@
             done();
           };
 
-          elementDate.addEventListener( "data-update", handler );
           elementDate.dispatchEvent( new CustomEvent( "start" ) );
-
           elementDate.setAttribute( "date", "2020-01-01" );
 
           assert.isTrue( elementDate._reset.calledOnce );
+
+          elementDate.addEventListener( "data-update", handler );
           clock.tick(60000);
         } );
 
@@ -131,12 +148,12 @@
             done();
           };
 
-          elementTime.addEventListener( "data-update", handler );
           elementTime.dispatchEvent( new CustomEvent( "start" ) );
-
           elementTime.setAttribute( "time", "20:00" );
 
           assert.isTrue( elementTime._reset.calledOnce );
+
+          elementTime.addEventListener( "data-update", handler );
           clock.tick(60000);
         } );
 
@@ -150,12 +167,12 @@
             done();
           };
 
-          elementTime.addEventListener( "data-update", handler );
           elementTime.dispatchEvent( new CustomEvent( "start" ) );
-
           elementTime.setAttribute( "completion", "Test!" );
 
           assert.isTrue( elementTime._reset.calledOnce );
+
+          elementTime.addEventListener( "data-update", handler );
           clock.tick(60000);
         } );
 

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -245,16 +245,16 @@
 
         suite( "_start", () => {
           setup( () => {
-            sandbox.stub( element, "_runTimer" );
+            sandbox.stub( element, "_processCount" );
             sandbox.stub( element, "_initializeDateDuration" );
           } );
 
-          test( "should call _runTimer() when type and date or time formats are valid", () => {
+          test( "should call _processCount() when type and date or time formats are valid", () => {
             element.type = "down";
             element.date = "2019-10-29";
             element._start();
 
-            assert.isTrue( element._runTimer.calledOnce );
+            assert.isTrue( element._processCount.calledWith( true ) );
           } );
 
           test( "should call _initializeDateDuration() when configured for valid date", () => {
@@ -265,14 +265,14 @@
             assert.isTrue( element._initializeDateDuration.calledWith( element.date ) );
           } );
 
-          test( "should not call _runTimer() and should send data-error event when type is invalid", ( done ) => {
+          test( "should not call _processCount() and should send data-error event when type is invalid", ( done ) => {
             const listener = ( evt ) => {
               assert.deepEqual( evt.detail, {
                 message: "Invalid type, valid values are 'down' and 'up'",
                 type: "test"
               } );
 
-              assert.isFalse( element._runTimer.calledOnce );
+              assert.isFalse( element._processCount.calledOnce );
 
               element.removeEventListener( "data-error", listener );
               done();
@@ -285,17 +285,17 @@
 
           } );
 
-          test( "should not call _runTimer() or send data-error event when empty date or time values", () => {
+          test( "should not call _processCount() or send data-error event when empty date or time values", () => {
             sinon.spy( element, "_sendCounterEvent" );
 
             element.type = "down";
             element._start();
 
-            assert.isFalse( element._runTimer.calledOnce );
+            assert.isFalse( element._processCount.calledOnce );
             assert.isFalse( element._sendCounterEvent.calledOnce );
           } );
 
-          test( "should not call _runTimer() and should send data-error event when date format is invalid", ( done ) => {
+          test( "should not call _processCount() and should send data-error event when date format is invalid", ( done ) => {
             const listener = ( evt ) => {
               assert.deepEqual( evt.detail, {
                 message: "Invalid format, valid date is YYYY-MM-DD and valid time is HH:mm",
@@ -303,7 +303,7 @@
                 time: element.time
               } );
 
-              assert.isFalse( element._runTimer.calledOnce );
+              assert.isFalse( element._processCount.calledOnce );
 
               element.removeEventListener( "data-error", listener );
               done();
@@ -315,7 +315,7 @@
             element._start();
           } );
 
-          test( "should not call _runTimer() and should send data-error event when time format is invalid", ( done ) => {
+          test( "should not call _processCount() and should send data-error event when time format is invalid", ( done ) => {
             const listener = ( evt ) => {
               assert.deepEqual( evt.detail, {
                 message: "Invalid format, valid date is YYYY-MM-DD and valid time is HH:mm",
@@ -323,7 +323,7 @@
                 time: element.time
               } );
 
-              assert.isFalse( element._runTimer.calledOnce );
+              assert.isFalse( element._processCount.calledOnce );
 
               element.removeEventListener( "data-error", listener );
               done();
@@ -347,6 +347,12 @@
             element.refresh = 60;
             element._start();
 
+            // processCount called from _start()
+            assert.isTrue( element._processCount.called );
+
+            // force timer to run
+            element._runTimer(element.refresh);
+
             clock.tick(30000);
 
             assert.isTrue( element._refreshDebounceJob.isActive() );
@@ -356,7 +362,7 @@
 
             clock.tick(30000);
 
-            assert.isFalse( element._processCount.called );
+            assert.isTrue( element._processCount.calledOnce );
             assert.isFalse( element._refreshDebounceJob.isActive() );
             assert.isNull( element._dateDuration );
           } );
@@ -566,6 +572,22 @@
         } );
 
         suite( "_getDateData", () => {
+          test( "should ignore updating date duration when truthy param value provided", () => {
+            sinon.spy(element, "_updateDateDuration");
+
+            // test a date that is before target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            element.date = "2019-10-29";
+            element.type = "down";
+            element.refresh = 10;
+
+            element._start();
+            element._getDateData( true );
+
+            assert.isFalse( element._updateDateDuration.called );
+          } );
+
           test( "should return object with all correct properties and values", () => {
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
@@ -623,7 +645,9 @@
             element._start();
             element._processCount();
 
-            assert.isTrue( element._sendCounterEvent.calledWith( 'data-update', {
+            // test 2nd call since _processCount() is also called from _start()
+            assert.equal( element._sendCounterEvent.args[1][0], "data-update" );
+            assert.deepEqual( element._sendCounterEvent.args[1][1], {
               date: {
                 targetDate: "2019-10-29",
                 type: "count down",
@@ -651,7 +675,7 @@
                 }
               },
               time: null
-            } ) );
+            } );
 
             assert.isTrue( element._runTimer.calledWith( 10 ) );
 
@@ -833,6 +857,22 @@
         } );
 
         suite( "_getTimeData", () => {
+          test( "should ignore updating time duration when truthy param value provided", () => {
+            sinon.spy(element, "_updateTimeDuration");
+
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element.time = "17:00";
+            element.type = "down";
+            element.refresh = 10;
+
+            element._start();
+            element._getTimeData( true );
+
+            assert.isFalse( element._updateTimeDuration.called );
+          } );
+
           test( "should return object with all correct properties and values", () => {
             // test a time that is before target time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});


### PR DESCRIPTION
## Description
No longer waiting until first refresh is complete to send a _data-update_ event. Now processes and sends _data-update_ after component starts.

## Motivation and Context
When a `refresh` value of for example 30 is set, the template won't receive a _data-update_ event until 30 seconds have past. This is detrimental to the template as it can't display any values until it has data. 

Providing data immediately after component starts provides the template the values it needs to render immediately. 

## How Has This Been Tested?
Locally with _example counter component_ template with Charles and ChrOS.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Merge today so Beta version is deployed for example template validation/testing. 
  - Will deploy to Stable on Monday and validate on production immediately after.
  - Rollback involves re-running previous CCI `build/stable` deployment 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Documentation, Support
