### PR TITLE
updates readme to say string for refresh rate instead of number

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This component receives the following list of attributes:
 - **date**: (string / optional): The date value to count up from or down to. Valid format is `YYYY-MM-DD`.
 - **time**: (string / optional): The time value to count up from or down to. Valid format is `HH:mm`.
 - **completion**: (string / optional): The message to display when the countdown is complete. Only used for a type configuration of `down`.
-- **refresh**: (number / optional): The rate at which the component should provide a new timestamp value. Unit is seconds and it defaults to `1`.
-- **non-completion**: ( empty /optional ): If present, it indicates the `completion` attribute should not be surfaced as editable to the user in Template Editor. This allows a `completion` value to be set on the instance of the component and it will persist. 
+- **refresh**: (string / optional): The rate at which the component should provide a new timestamp value. Unit is seconds and it defaults to `1`.
+- **non-completion**: ( empty /optional ): If present, it indicates the `completion` attribute should not be surfaced as editable to the user in Template Editor. This allows a `completion` value to be set on the instance of the component and it will persist.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor.
 
 This component does not support PUD; it will need to be handled by Designers on a per Template basis.
@@ -62,7 +62,7 @@ For `date`, the following properties are available:
 For `time`, the following properties are available:
 - Both `duration` and `difference` contain: `hours`, `minutes`, `seconds`, `milliseconds`.
 - The `targetTime` property indicates the time the user or designer chose for this instance.
-- **Note** - `time` will have data populated if no date was configured on the instance. If both date and time were configured on the instance, then the data will be populated in the `date` object and `time` will be `null`.   
+- **Note** - `time` will have data populated if no date was configured on the instance. If both date and time were configured on the instance, then the data will be populated in the `date` object and `time` will be `null`.
 
 For type equals to `down`, the following exclusive properties will be available inside the `details` object:
 - `completed`: A boolean indicating the target date/time was reached.


### PR DESCRIPTION
## Description
Updates readme for refresh rate - changes from saying it takes a number to a string to match the example syntax.

## Motivation and Context
Refresh rate needs to be added as a string like "60" rather than a number integer 60. This change is just to avoid confusion as I tried to add `refresh=60` as an attribute.

## How Has This Been Tested?
Checked my dictionary on how to spell string 😄 

## Release Plan:
N/A

#### Release Checklist Items Skipped?
N/A
