### PR TITLE
Check if month is January before considering it invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-counter",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-counter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rise data counter component",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-data-counter.js
+++ b/src/rise-data-counter.js
@@ -186,7 +186,7 @@ export default class RiseDataCounter extends RiseElement {
   }
 
   _formatMomentJSMonth( month ) {
-    if ( !month || isNaN( month ) || month < 0 || month > 11) {
+    if ( (month !== 0 && !month) || isNaN( month ) || month < 0 || month > 11) {
       return "";
     }
 

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -827,6 +827,7 @@
           } );
 
           test( "should return month correctly formatted", () => {
+            assert.equal( element._formatMomentJSMonth( 0 ), "01" );
             assert.equal( element._formatMomentJSMonth( 2 ), "03" );
             assert.equal( element._formatMomentJSMonth( 9 ), "10" );
             assert.equal( element._formatMomentJSMonth( 11 ), "12" );
@@ -969,6 +970,25 @@
               milliseconds: 12600000,
               minutes: 210,
               seconds: 12600,
+            } )
+          } );
+
+          test( "should return object with all correct properties and values based on 'down' type when month is Januart", () => {
+            // test a time that is before target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T15:45", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            element._initializeTimeDuration( "17:00", "down" );
+
+            // simulate a 10 second interval
+            element._updateTimeDuration( 10 * 1000, "down" );
+
+            const formatted = element._getTimeDifferenceFormatted( "17:00", "down" );
+
+            assert.deepEqual( formatted, {
+              hours: 1,
+              milliseconds: 4500000,
+              minutes: 75,
+              seconds: 4500,
             } )
           } );
 


### PR DESCRIPTION
## Description
Checks for 0 when formatting a month to avoid returning empty string.

## Motivation and Context
_Specific Time_ instances were providing invalid values to clients. 

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/8b35ce55-44f4-4848-be22-0663e2adae33/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
