### PR TITLE
Fix inefficiency in providing duration units per refresh interval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,32 +5,31 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
-        "@babel/helper-module-transforms": "^7.10.5",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.10.5",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
@@ -43,69 +42,71 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
       "requires": {
-        "@babel/types": "^7.10.5",
+        "@babel/types": "^7.12.11",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-      "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
       "requires": {
-        "@babel/types": "^7.10.5"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-      "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.5",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -114,46 +115,45 @@
       "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-member-expression-to-functions": "^7.12.7",
+        "@babel/helper-optimise-call-expression": "^7.12.10",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/highlight": {
@@ -167,9 +167,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -204,26 +204,26 @@
       }
     },
     "@babel/template": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.10.5",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
-        "@babel/parser": "^7.10.5",
-        "@babel/types": "^7.10.5",
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -237,11 +237,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
@@ -285,9 +285,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -299,35 +299,30 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
     "@webcomponents/shadycss": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
-      "integrity": "sha512-UMS+dF4DXDrcUmQqK6aLd/3mFyfGktKG/hZR6FtrsQK/INO07G0H8FxElLkuvHj0iePeZGpR7R4lWFTvX7rc9g=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+      "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz",
-      "integrity": "sha512-cV4+sAmshf8ysU2USutrSRYQkJzEYKHsRCGa0CkMElGpG5747VHtkfsW3NdVIBV/m2MDKXTDydT4lkrysH7IFA=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
+      "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q=="
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -450,9 +445,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -698,9 +693,9 @@
       }
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -723,6 +718,15 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -879,9 +883,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -928,11 +932,11 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1018,21 +1022,35 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "es-to-primitive": {
@@ -1095,11 +1113,11 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -1140,18 +1158,25 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
         }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+        }
       }
     },
     "estraverse": {
@@ -1290,9 +1315,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "requires": {
         "is-buffer": "~2.0.3"
       }
@@ -1362,9 +1387,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1375,6 +1400,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -1480,11 +1515,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
     },
@@ -1563,9 +1598,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1591,9 +1626,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
@@ -1601,7 +1636,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.16",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -1611,11 +1646,10 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -1655,9 +1689,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1686,14 +1720,22 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -1741,6 +1783,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1757,9 +1804,9 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -1890,9 +1937,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1913,9 +1960,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1971,9 +2018,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2026,9 +2073,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2115,16 +2162,16 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -2326,9 +2373,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -2347,12 +2394,13 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "object.omit": {
@@ -2373,9 +2421,9 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -2719,10 +2767,11 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -2749,8 +2798,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#aa7ad1a9ecfe9f386321bd790c94219e8e41c695",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.5.2",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#3703756d9955c8ee6dd5cb82fb7df8d606ffb8f7",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.6.1",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@polymer/test-fixture": "~4.0.2",
@@ -2770,9 +2819,9 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "rxjs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
-      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -2816,16 +2865,16 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
       "requires": {
         "@sinonjs/commons": "^1.7.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
+        "@sinonjs/samsam": "^5.1.0",
         "diff": "^4.0.2",
-        "nise": "^4.0.1",
+        "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -2840,9 +2889,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -2895,9 +2944,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -2941,21 +2990,21 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "strip-ansi": {
@@ -3092,9 +3141,9 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -3128,15 +3177,15 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
+      "integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
       "optional": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3147,9 +3196,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -3306,9 +3355,9 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/test/unit/rise-data-counter.html
+++ b/test/unit/rise-data-counter.html
@@ -262,7 +262,6 @@
         suite( "_start", () => {
           setup( () => {
             sandbox.stub( element, "_processCount" );
-            sandbox.stub( element, "_initializeDateDuration" );
           } );
 
           test( "should call _processCount() when type and date or time formats are valid", () => {
@@ -270,15 +269,7 @@
             element.date = "2019-10-29";
             element._start();
 
-            assert.isTrue( element._processCount.calledWith( true ) );
-          } );
-
-          test( "should call _initializeDateDuration() when configured for valid date", () => {
-            element.type = "down";
-            element.date = "2019-10-29";
-            element._start();
-
-            assert.isTrue( element._initializeDateDuration.calledWith( element.date ) );
+            assert.isTrue( element._processCount.called );
           } );
 
           test( "should not call _processCount() and should send data-error event when type is invalid", ( done ) => {
@@ -372,7 +363,6 @@
             clock.tick(30000);
 
             assert.isTrue( element._refreshDebounceJob.isActive() );
-            assert.isNotNull( element._dateDuration );
 
             element._stop();
 
@@ -380,7 +370,6 @@
 
             assert.isTrue( element._processCount.calledOnce );
             assert.isFalse( element._refreshDebounceJob.isActive() );
-            assert.isNull( element._dateDuration );
           } );
 
         } );
@@ -410,151 +399,15 @@
 
         } );
 
-        suite( "_initializeDateDuration", () => {
-          test( "should initialize correct duration with given target date based on 'down' type", () => {
-            // test a date that is before target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), 2419200000 );
-            assert.equal( element._dateDuration.asDays(), 28 );
-
-            // test a date that is same as target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), 0 );
-            assert.equal( element._dateDuration.asDays(), 0 );
-
-            // test a date that has passed target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-11-01", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), -259200000 );
-            assert.equal( element._dateDuration.asDays(), -3 );
-
-          } );
-
-          test( "should initialize correct duration with given target date based on 'up' type", () => {
-            // test a date that is after target date to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-01", undefined, "up" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), 2419200000 );
-            assert.equal( element._dateDuration.asDays(), 28 );
-
-            // test a date that is same as target date to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "up" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), 0 );
-            assert.equal( element._dateDuration.asDays(), 0 );
-
-            // test a date that is before target date to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "up" );
-
-            assert.equal( element._dateDuration.asMilliseconds(), -2419200000 );
-            assert.equal( element._dateDuration.asDays(), -28 );
-
-          } );
-
-          test( "should initialize correct duration with given target date AND time", () => {
-            // test a date that is before target date and time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T17:20", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", "08:00", "down" );
-
-            assert.equal( element._dateDuration.days(), 27 );
-            assert.equal( element._dateDuration.hours(), 14 );
-            assert.equal( element._dateDuration.minutes(), 40 );
-
-            // test a date and time that is same as target date and time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-29T08:00", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", "08:00", "down" );
-
-            assert.equal( element._dateDuration.days(), 0 );
-            assert.equal( element._dateDuration.hours(), 0 );
-            assert.equal( element._dateDuration.minutes(), 0 );
-
-            // test a date and time that has passed target date and time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-11-01T14:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", "08:00", "down" );
-
-            assert.equal( element._dateDuration.days(), -3 );
-            assert.equal( element._dateDuration.hours(), -6 );
-            assert.equal( element._dateDuration.minutes(), -30 );
-
-          } );
-        } );
-
-        suite( "_updateDateDuration", () => {
-          test( "should update correct duration with given interval (MS) and based on 'down' type", () => {
-            // test a date that is before target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
-            assert.equal( element._dateDuration.days(), 28 );
-
-            // simulate a 24 hour interval
-            element._updateDateDuration( 24 * 60 * 60 * 1000, "down" );
-
-            assert.equal( element._dateDuration.days(), 27 );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "down" );
-
-            assert.equal( element._dateDuration.seconds(), 50 );
-
-            element._updateDateDuration( 10 * 1000, "down" );
-
-            assert.equal( element._dateDuration.seconds(), 40 );
-          } );
-
-          test( "should update correct duration with given interval (MS) and based on 'up' type", () => {
-            // test a date that is before target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-01", undefined, "up" );
-
-            assert.equal( element._dateDuration.days(), 28 );
-
-            // simulate a 24 hour interval
-            element._updateDateDuration( 24 * 60 * 60 * 1000, "up" );
-
-            assert.equal( element._dateDuration.days(), 29 );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "up" );
-
-            assert.equal( element._dateDuration.seconds(), 10 );
-
-            element._updateDateDuration( 10 * 1000, "up" );
-
-            assert.equal( element._dateDuration.seconds(), 20 );
-          } );
-        } );
-
         suite( "_getDateDurationFormatted", () => {
-          test( "should return object with all correct properties and values", () => {
+          test( "should return object with all correct properties and values with given target date based on 'down' type", () => {
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
 
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
             // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "down" );
+            clock.tick(10000);
 
-            const formatted = element._getDateDurationFormatted();
+            let formatted = element._getDateDurationFormatted( "2019-10-29", undefined, "down" );
 
             assert.deepEqual( formatted, {
               days: 27,
@@ -565,7 +418,139 @@
               seconds: 50,
               weeks: 3,
               years: 0
-            } )
+            } );
+
+            // test a date that is same as target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", undefined, "down" );
+
+            assert.deepEqual( formatted, {
+              days: 0,
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              months: 0,
+              seconds: 0,
+              weeks: 0,
+              years: 0
+            } );
+
+            // test a date that has passed target date to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-11-01", "YYYY-MM-DD").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", undefined, "down" );
+
+            assert.deepEqual( formatted, {
+              days: -3,
+              hours: -0,
+              milliseconds: -0,
+              minutes: -0,
+              months: 0,
+              seconds: -0,
+              weeks: 0,
+              years: 0
+            } );
+          } );
+
+          test( "should return object with all correct properties and values with given target date based on 'up' type", () => {
+            // test a date that is after target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            let formatted = element._getDateDurationFormatted( "2019-10-01", undefined, "up" );
+
+            assert.deepEqual( formatted, {
+              days: 28,
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              months: 0,
+              seconds: 0,
+              weeks: 4,
+              years: 0
+            } );
+
+            // test a date that is same as target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", undefined, "up" );
+
+            assert.deepEqual( formatted, {
+              days: 0,
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              months: 0,
+              seconds: 0,
+              weeks: 0,
+              years: 0
+            } );
+
+            // test a date that is before target date to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", undefined, "up" );
+
+            assert.deepEqual( formatted, {
+              days: -28,
+              hours: -0,
+              milliseconds: -0,
+              minutes: -0,
+              months: 0,
+              seconds: -0,
+              weeks: -4,
+              years: 0
+            } );
+          } );
+
+          test( "should return object with all correct properties and values with given target date AND time", () => {
+            // test a date that is before target date and time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T17:20", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            let formatted = element._getDateDurationFormatted( "2019-10-29", "08:00", "down" );
+
+            assert.deepEqual( formatted, {
+              days: 27,
+              hours: 14,
+              milliseconds: 0,
+              minutes: 40,
+              months: 0,
+              seconds: 0,
+              weeks: 3,
+              years: 0
+            } );
+
+            // test a date and time that is same as target date and time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-29T08:00", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", "08:00", "down" );
+
+            assert.deepEqual( formatted, {
+              days: 0,
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              months: 0,
+              seconds: 0,
+              weeks: 0,
+              years: 0
+            } );
+
+            // test a date and time that has passed target date and time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-11-01T14:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getDateDurationFormatted( "2019-10-29", "08:00", "down" );
+
+            assert.deepEqual( formatted, {
+              days: -3,
+              hours: -6,
+              milliseconds: -0,
+              minutes: -30,
+              months: 0,
+              seconds: -0,
+              weeks: 0,
+              years: 0
+            } );
           } );
         } );
 
@@ -573,11 +558,6 @@
           test( "should return object with all correct properties and values based on 'down' type", () => {
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-29", undefined, "down" );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "down" );
 
             const formatted = element._getDateDifferenceFormatted( "2019-10-29", undefined, "down" );
 
@@ -597,11 +577,6 @@
             // test a date and time that is before target date and time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T06:15", "YYYY-MM-DDTHH:mm").valueOf()});
 
-            element._initializeDateDuration( "2019-10-29", "11:30", "down" );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "down" );
-
             const formatted = element._getDateDifferenceFormatted( "2019-10-29", "11:30", "down" );
 
             assert.deepEqual( formatted, {
@@ -619,11 +594,6 @@
           test( "should return object with all correct properties and values based on 'up' type", () => {
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-29", "YYYY-MM-DD").valueOf()});
-
-            element._initializeDateDuration( "2019-10-01", undefined, "up" );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "up" );
 
             const formatted = element._getDateDifferenceFormatted( "2019-10-01", undefined, "up" );
 
@@ -643,11 +613,6 @@
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-29T13:00", "YYYY-MM-DDTHH:mm").valueOf()});
 
-            element._initializeDateDuration( "2019-10-01", "08:45", "up" );
-
-            // simulate a 10 second interval
-            element._updateDateDuration( 10 * 1000, "up" );
-
             const formatted = element._getDateDifferenceFormatted( "2019-10-01", "08:45", "up" );
 
             assert.deepEqual( formatted, {
@@ -664,22 +629,6 @@
         } );
 
         suite( "_getDateData", () => {
-          test( "should ignore updating date duration when truthy param value provided", () => {
-            sinon.spy(element, "_updateDateDuration");
-
-            // test a date that is before target date to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
-
-            element.date = "2019-10-29";
-            element.type = "down";
-            element.refresh = 10;
-
-            element._start();
-            element._getDateData( true );
-
-            assert.isFalse( element._updateDateDuration.called );
-          } );
-
           test( "should return object with all correct properties and values", () => {
             // test a date that is before target date to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01", "YYYY-MM-DD").valueOf()});
@@ -699,13 +648,13 @@
               completed: false,
               completion: undefined,
               duration: {
-                days: 27,
-                hours: 23,
+                days: 28,
+                hours: 0,
                 milliseconds: 0,
-                minutes: 59,
+                minutes: 0,
                 months: 0,
-                seconds: 50,
-                weeks: 3,
+                seconds: 0,
+                weeks: 4,
                 years: 0
               },
               difference: {
@@ -744,9 +693,9 @@
                 days: 27,
                 hours: 15,
                 milliseconds: 0,
-                minutes: 29,
+                minutes: 30,
                 months: 0,
-                seconds: 50,
+                seconds: 0,
                 weeks: 3,
                 years: 0
               },
@@ -777,12 +726,11 @@
             element.type = "down";
             element.refresh = 10;
 
-            element._start();
             element._processCount();
 
             // test 2nd call since _processCount() is also called from _start()
-            assert.equal( element._sendCounterEvent.args[1][0], "data-update" );
-            assert.deepEqual( element._sendCounterEvent.args[1][1], {
+            assert.equal( element._sendCounterEvent.args[0][0], "data-update" );
+            assert.deepEqual( element._sendCounterEvent.args[0][1], {
               date: {
                 targetDate: "2019-10-29",
                 targetTime: "00:00",
@@ -790,13 +738,13 @@
                 completed: false,
                 completion: undefined,
                 duration: {
-                  days: 27,
-                  hours: 23,
+                  days: 28,
+                  hours: 0,
                   milliseconds: 0,
-                  minutes: 59,
+                  minutes: 0,
                   months: 0,
-                  seconds: 50,
-                  weeks: 3,
+                  seconds: 0,
+                  weeks: 4,
                   years: 0
                 },
                 difference: {
@@ -834,122 +782,81 @@
           });
         } );
 
-        suite( "_initializeTimeDuration", () => {
-          test( "should initialize correct duration with given target time based on 'down' type", () => {
-            // test a time that is before target time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "17:00", "down" );
-
-            assert.equal( element._timeDuration.hours(), 3 );
-            assert.equal( element._timeDuration.minutes(), 30 );
-
-            // test a time that is same as target time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "13:30", "down" );
-
-            assert.equal( element._timeDuration.hours(), 0 );
-            assert.equal( element._timeDuration.minutes(), 0 );
-
-            // test a time that has passed target time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T18:45", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "17:00", "down" );
-
-            assert.equal( element._timeDuration.hours(), -1 );
-            assert.equal( element._timeDuration.minutes(), -45 );
-
-          } );
-
-          test( "should initialize correct duration with given target time based on 'up' type", () => {
-            // test a time that is after target time to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "09:00", "up" );
-
-            assert.equal( element._timeDuration.hours(), 4 );
-            assert.equal( element._timeDuration.minutes(), 30 );
-
-            // test a time that is same as target time to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "13:30", "up" );
-
-            assert.equal( element._timeDuration.hours(), 0 );
-            assert.equal( element._timeDuration.minutes(), 0 );
-
-            // test a time that is before target time to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "17:00", "up" );
-
-            assert.equal( element._timeDuration.hours(), -3 );
-            assert.equal( element._timeDuration.minutes(), -30 );
-
-          } );
-        } );
-
-        suite( "_updateTimeDuration", () => {
-          test( "should update correct duration with given interval (MS) and based on 'down' type", () => {
-            // test a time that is before target time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "17:00", "down" );
-
-            assert.equal( element._timeDuration.hours(), 3 );
-            assert.equal( element._timeDuration.minutes(), 30 );
-            assert.equal( element._timeDuration.seconds(), 0 );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "down" );
-
-            assert.equal( element._timeDuration.seconds(), 50 );
-
-            element._updateTimeDuration( 10 * 1000, "down" );
-
-            assert.equal( element._timeDuration.seconds(), 40 );
-          } );
-
-          test( "should update correct duration with given interval (MS) and based on 'up' type", () => {
-            // test a time that is after target time to start from
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "9:00", "up" );
-
-            assert.equal( element._timeDuration.hours(), 4 );
-            assert.equal( element._timeDuration.minutes(), 30 );
-            assert.equal( element._timeDuration.seconds(), 0 );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "up" );
-
-            assert.equal( element._timeDuration.seconds(), 10 );
-
-            element._updateTimeDuration( 10 * 1000, "up" );
-
-            assert.equal( element._timeDuration.seconds(), 20 );
-          } );
-        } );
-
         suite( "_getTimeDurationFormatted", () => {
-          test( "should return object with all correct properties and values", () => {
+          test( "should return object with all correct properties and values given target time based on 'down' type", () => {
             // test a time that is before target time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
 
-            element._initializeTimeDuration( "17:00", "down" );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "down" );
-
-            const formatted = element._getTimeDurationFormatted();
+            let formatted = element._getTimeDurationFormatted("17:00", "down");
 
             assert.deepEqual( formatted, {
               hours: 3,
               milliseconds: 0,
-              minutes: 29,
-              seconds: 50
-            } )
+              minutes: 30,
+              seconds: 0
+            } );
+
+            // test a time that is same as target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getTimeDurationFormatted( "13:30", "down" );
+
+            assert.deepEqual( formatted, {
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              seconds: 0
+            } );
+
+            // test a time that has passed target time to count down to
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T18:45", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getTimeDurationFormatted( "17:00", "down" );
+
+            assert.deepEqual( formatted, {
+              hours: -1,
+              milliseconds: -0,
+              minutes: -45,
+              seconds: -0
+            } );
+          } );
+
+          test( "should return object with all correct properties and values given target time based on 'up' type", () => {
+            // test a time that is after target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            let formatted = element._getTimeDurationFormatted( "09:00", "up" );
+
+            assert.deepEqual( formatted, {
+              hours: 4,
+              milliseconds: 0,
+              minutes: 30,
+              seconds: 0
+            } );
+
+            // test a time that is same as target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getTimeDurationFormatted( "13:30", "up" );
+
+            assert.deepEqual( formatted, {
+              hours: 0,
+              milliseconds: 0,
+              minutes: 0,
+              seconds: 0
+            } );
+
+            // test a time that is before target time to start from
+            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
+
+            formatted = element._getTimeDurationFormatted( "17:00", "up" );
+
+            assert.deepEqual( formatted, {
+              hours: -3,
+              milliseconds: -0,
+              minutes: -30,
+              seconds: -0
+            } );
           } );
         } );
 
@@ -957,11 +864,6 @@
           test( "should return object with all correct properties and values based on 'down' type", () => {
             // test a time that is before target time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element._initializeTimeDuration( "17:00", "down" );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "down" );
 
             const formatted = element._getTimeDifferenceFormatted( "17:00", "down" );
 
@@ -977,11 +879,6 @@
             // test a time that is before target time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T15:45", "YYYY-MM-DDTHH:mm").valueOf()});
 
-            element._initializeTimeDuration( "17:00", "down" );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "down" );
-
             const formatted = element._getTimeDifferenceFormatted( "17:00", "down" );
 
             assert.deepEqual( formatted, {
@@ -996,11 +893,6 @@
             // test a time that is after target time to start from
             clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
 
-            element._initializeTimeDuration( "9:00", "up" );
-
-            // simulate a 10 second interval
-            element._updateTimeDuration( 10 * 1000, "up" );
-
             const formatted = element._getTimeDifferenceFormatted( "09:00", "up" );
 
             assert.deepEqual( formatted, {
@@ -1013,22 +905,6 @@
         } );
 
         suite( "_getTimeData", () => {
-          test( "should ignore updating time duration when truthy param value provided", () => {
-            sinon.spy(element, "_updateTimeDuration");
-
-            // test a time that is before target time to count down to
-            clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
-
-            element.time = "17:00";
-            element.type = "down";
-            element.refresh = 10;
-
-            element._start();
-            element._getTimeData( true );
-
-            assert.isFalse( element._updateTimeDuration.called );
-          } );
-
           test( "should return object with all correct properties and values", () => {
             // test a time that is before target time to count down to
             clock = sinon.useFakeTimers({now: moment("2019-10-01T13:30", "YYYY-MM-DDTHH:mm").valueOf()});
@@ -1049,8 +925,8 @@
               duration: {
                 hours: 3,
                 milliseconds: 0,
-                minutes: 29,
-                seconds: 50
+                minutes: 30,
+                seconds: 0
               },
               difference: {
                 hours: 3,


### PR DESCRIPTION
## Description
No longer storing a previous duration value to increase/decrease by as per refresh interval. Instead, doing full calculation and formatting upon every refresh interval without referencing any previously stored duration value. 

## Motivation and Context
Fixes issue https://github.com/Rise-Vision/html-template-library/issues/1777 as the inefficiency mentioned above was causing duration values to sometimes be progressively behind, particularly in a long countdown. 

## How Has This Been Tested?
Tested with presentation https://apps.risevision.com/templates/edit/1bb41942-a8e5-45c6-b9b7-c79edfc6b6a3/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f in Electron Player via Charles mapping to local version of component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
